### PR TITLE
[BUGFIX] Fix workflow errors for the VL53C4X driver. Adopt the Flash driver for usage with Littlefs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/src/i2c/i2c.c
         ${CMAKE_CURRENT_LIST_DIR}/src/w25qxx128/w25qxx128.c
         ${CMAKE_CURRENT_LIST_DIR}/src/sample_timer/sample_timer.c
         ${CMAKE_CURRENT_LIST_DIR}/src/vl6180x/vl6180x.c
+        ${CMAKE_CURRENT_LIST_DIR}/src/vl53l4cd/vl53l4cd.c
         ${CMAKE_CURRENT_LIST_DIR}/src/error_handler/error_handler.c
         ${CMAKE_CURRENT_LIST_DIR}/src/sdp810/sdp810.c
         ${CMAKE_CURRENT_LIST_DIR}/src/ads7138/ads7138.c

--- a/src/vl53l4cd/private/vl53l4cd_regs.h
+++ b/src/vl53l4cd/private/vl53l4cd_regs.h
@@ -30,54 +30,54 @@ extern "C"
 #endif
 
 /* Device identification */
-#define VL53L4CD_IDENTIFICATION_MODEL_ID       0x010Fu
+#define VL53L4CD_IDENTIFICATION_MODEL_ID 0x010Fu
 
 /* System registers */
-#define VL53L4CD_FIRMWARE_SYSTEM_STATUS        0x00E5u
-#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR        0x0086u
-#define VL53L4CD_SYSTEM_START                  0x0087u
-#define VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET     0x0016u /* Similar to VL6180X */
+#define VL53L4CD_FIRMWARE_SYSTEM_STATUS    0x00E5u
+#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR    0x0086u
+#define VL53L4CD_SYSTEM_START              0x0087u
+#define VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET 0x0016u /* Similar to VL6180X */
 
 /* Ranging configuration registers */
-#define VL53L4CD_RANGE_CONFIG_A                0x005Eu
-#define VL53L4CD_RANGE_CONFIG_B                0x0061u
-#define VL53L4CD_RANGE_CONFIG_SIGMA_THRESH     0x0064u
-#define VL53L4CD_INTERMEASUREMENT_MS           0x006Cu
-#define VL53L4CD_THRESH_HIGH                   0x0072u
-#define VL53L4CD_THRESH_LOW                    0x0074u
+#define VL53L4CD_RANGE_CONFIG_A            0x005Eu
+#define VL53L4CD_RANGE_CONFIG_B            0x0061u
+#define VL53L4CD_RANGE_CONFIG_SIGMA_THRESH 0x0064u
+#define VL53L4CD_INTERMEASUREMENT_MS       0x006Cu
+#define VL53L4CD_THRESH_HIGH               0x0072u
+#define VL53L4CD_THRESH_LOW                0x0074u
 
 /* Result registers */
-#define VL53L4CD_RESULT_RANGE_STATUS           0x0089u
-#define VL53L4CD_RESULT_SPAD_NB                0x008Cu
-#define VL53L4CD_RESULT_SIGNAL_RATE            0x008Eu
-#define VL53L4CD_RESULT_AMBIENT_RATE           0x0090u
-#define VL53L4CD_RESULT_SIGMA                  0x0092u
-#define VL53L4CD_RESULT_FINAL_RANGE_MM         0x0096u
+#define VL53L4CD_RESULT_RANGE_STATUS   0x0089u
+#define VL53L4CD_RESULT_SPAD_NB        0x008Cu
+#define VL53L4CD_RESULT_SIGNAL_RATE    0x008Eu
+#define VL53L4CD_RESULT_AMBIENT_RATE   0x0090u
+#define VL53L4CD_RESULT_SIGMA          0x0092u
+#define VL53L4CD_RESULT_FINAL_RANGE_MM 0x0096u
 
 /* VHV configuration registers */
-#define VL53L4CD_VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND  0x0008u
+#define VL53L4CD_VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND 0x0008u
 
 /* I2C and configuration registers */
-#define VL53L4CD_I2C_SLAVE_DEVICE_ADDRESS      0x0001u
-#define VL53L4CD_OSC_CALIBRATE_VAL             0x00DEu
+#define VL53L4CD_I2C_SLAVE_DEVICE_ADDRESS 0x0001u
+#define VL53L4CD_OSC_CALIBRATE_VAL        0x00DEu
 
 /* Default I2C addresses */
-#define VL53L4CD_DEFAULT_ADDR                  0x52u /* 7-bit address */
-#define VL53L4CD_DEFAULT_ADDR_ALT              0x29u /* Alternative address */
+#define VL53L4CD_DEFAULT_ADDR     0x52u /* 7-bit address */
+#define VL53L4CD_DEFAULT_ADDR_ALT 0x29u /* Alternative address */
 
 /* Start/stop values */
-#define VL53L4CD_RANGING_START                 0x40u
-#define VL53L4CD_RANGING_STOP                  0x00u
+#define VL53L4CD_RANGING_START 0x40u
+#define VL53L4CD_RANGING_STOP  0x00u
 
 /* Interrupt clear value */
-#define VL53L4CD_CLEAR_INTERRUPT               0x01u
+#define VL53L4CD_CLEAR_INTERRUPT 0x01u
 
 /* Model ID value */
-#define VL53L4CD_MODEL_ID_VALUE                0xEACCu
+#define VL53L4CD_MODEL_ID_VALUE 0xEACCu
 
 /* Status codes */
-#define VL53L4CD_NO_ERROR                      0u
-#define VL53L4CD_ERROR                         1u
+#define VL53L4CD_NO_ERROR 0u
+#define VL53L4CD_ERROR    1u
 
 #ifdef __cplusplus
 }

--- a/src/vl53l4cd/private/vl53l4cd_regs.h
+++ b/src/vl53l4cd/private/vl53l4cd_regs.h
@@ -1,0 +1,85 @@
+/**
+ * @file            vl53l4cd_regs.h
+ * @brief           Header file with registers for the STM VL53L4CD ranging ToF sensor
+ *
+ * @par
+ * Copyright 2025 (C) RobotPatient Simulators
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is part of the Manikin Software Libraries V3 project
+ *
+ * Author:          Johan Korten
+ */
+
+#ifndef VL53L4CD_REGS_H
+#define VL53L4CD_REGS_H
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Device identification */
+#define VL53L4CD_IDENTIFICATION_MODEL_ID       0x010Fu
+
+/* System registers */
+#define VL53L4CD_FIRMWARE_SYSTEM_STATUS        0x00E5u
+#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR        0x0086u
+#define VL53L4CD_SYSTEM_START                  0x0087u
+#define VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET     0x0016u /* Similar to VL6180X */
+
+/* Ranging configuration registers */
+#define VL53L4CD_RANGE_CONFIG_A                0x005Eu
+#define VL53L4CD_RANGE_CONFIG_B                0x0061u
+#define VL53L4CD_RANGE_CONFIG_SIGMA_THRESH     0x0064u
+#define VL53L4CD_INTERMEASUREMENT_MS           0x006Cu
+#define VL53L4CD_THRESH_HIGH                   0x0072u
+#define VL53L4CD_THRESH_LOW                    0x0074u
+
+/* Result registers */
+#define VL53L4CD_RESULT_RANGE_STATUS           0x0089u
+#define VL53L4CD_RESULT_SPAD_NB                0x008Cu
+#define VL53L4CD_RESULT_SIGNAL_RATE            0x008Eu
+#define VL53L4CD_RESULT_AMBIENT_RATE           0x0090u
+#define VL53L4CD_RESULT_SIGMA                  0x0092u
+#define VL53L4CD_RESULT_FINAL_RANGE_MM         0x0096u
+
+/* VHV configuration registers */
+#define VL53L4CD_VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND  0x0008u
+
+/* I2C and configuration registers */
+#define VL53L4CD_I2C_SLAVE_DEVICE_ADDRESS      0x0001u
+#define VL53L4CD_OSC_CALIBRATE_VAL             0x00DEu
+
+/* Default I2C addresses */
+#define VL53L4CD_DEFAULT_ADDR                  0x52u /* 7-bit address */
+#define VL53L4CD_DEFAULT_ADDR_ALT              0x29u /* Alternative address */
+
+/* Start/stop values */
+#define VL53L4CD_RANGING_START                 0x40u
+#define VL53L4CD_RANGING_STOP                  0x00u
+
+/* Interrupt clear value */
+#define VL53L4CD_CLEAR_INTERRUPT               0x01u
+
+/* Model ID value */
+#define VL53L4CD_MODEL_ID_VALUE                0xEACCu
+
+/* Status codes */
+#define VL53L4CD_NO_ERROR                      0u
+#define VL53L4CD_ERROR                         1u
+
+#ifdef __cplusplus
+}
+#endif
+#endif // VL53L4CD_REGS_H

--- a/src/vl53l4cd/vl53l4cd.c
+++ b/src/vl53l4cd/vl53l4cd.c
@@ -1,0 +1,194 @@
+/**
+ * @file            vl53l4cd.c
+ * @brief           Driver implementation for STM VL53L4CD ranging ToF sensor
+ *
+ * @par
+ * Copyright 2025 (C) RobotPatient Simulators
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is part of the Manikin Software Libraries V3 project
+ *
+ * Author:          Johan Korten
+ */
+
+#include "vl53l4cd.h"
+
+#include "common/manikin_bit_manipulation.h"
+#include "i2c/i2c.h"
+#include "private/vl53l4cd_regs.h"
+#include "error_handler/error_handler.h"
+
+#define HASH_VL53L4CD 0xE2B0299Eu
+
+/* Initialize the sensor with these register settings */
+static const manikin_sensor_reg_t vl53l4cd_init_regs[]
+    = {
+        /* System configuration */
+        { VL53L4CD_VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND, 0x09, MANIKIN_SENSOR_REG_TYPE_WRITE },
+        
+        /* Sensor timing configurations */
+        { VL53L4CD_RANGE_CONFIG_A, 0x09, MANIKIN_SENSOR_REG_TYPE_WRITE },
+        { VL53L4CD_RANGE_CONFIG_B, 0x09, MANIKIN_SENSOR_REG_TYPE_WRITE },
+        
+        /* Set timing budget to 50ms (default) */
+        { VL53L4CD_INTERMEASUREMENT_MS, 0x32, MANIKIN_SENSOR_REG_TYPE_WRITE },
+        
+        /* Configure sigma threshold (default is 15 mm) */
+        { VL53L4CD_RANGE_CONFIG_SIGMA_THRESH, 0x0F, MANIKIN_SENSOR_REG_TYPE_WRITE },
+        
+        /* Clear any pending interrupts */
+        { VL53L4CD_SYSTEM_INTERRUPT_CLEAR, VL53L4CD_CLEAR_INTERRUPT, MANIKIN_SENSOR_REG_TYPE_WRITE },
+      };
+
+/**
+ * @brief Internal function to check the parameters entered into function
+ * @param sensor_ctx The sensor settings ptr which should contain i2c bus details
+ * @return - MANIKIN_STATUS_OK if all parameters are valid
+ *         - MANIKIN_STATUS_ERR_NULL_PARAM if invalid
+ */
+static manikin_status_t
+vl53l4cd_check_params (manikin_sensor_ctx_t *sensor_ctx)
+{
+    MANIKIN_ASSERT(HASH_VL53L4CD, (sensor_ctx != NULL), MANIKIN_STATUS_ERR_NULL_PARAM);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (sensor_ctx->i2c != NULL), MANIKIN_STATUS_ERR_NULL_PARAM);
+    return MANIKIN_STATUS_OK;
+}
+
+manikin_status_t
+vl53l4cd_init_sensor (manikin_sensor_ctx_t *sensor_ctx)
+{
+    manikin_status_t status = vl53l4cd_check_params(sensor_ctx);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    sensor_ctx->needs_reinit = 0;
+    uint8_t data[2]          = {0};
+    uint16_t model_id        = 0;
+    
+    /* Check sensor fresh-out-of-reset bit, similar to VL6180X approach */
+    status = manikin_i2c_read_reg(sensor_ctx->i2c, 
+                                sensor_ctx->i2c_addr, 
+                                VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET, 
+                                &data[0]);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Check if sensor is responding by reading the model ID */
+    status = manikin_i2c_read_reg16(sensor_ctx->i2c, 
+                                   sensor_ctx->i2c_addr, 
+                                   VL53L4CD_IDENTIFICATION_MODEL_ID, 
+                                   data);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Check model ID is correct (0xEACC) */
+    model_id = (uint16_t)((data[0] << 8) | data[1]);
+    MANIKIN_NON_CRIT_ASSERT(HASH_VL53L4CD, 
+                           (model_id == VL53L4CD_MODEL_ID_VALUE), 
+                           MANIKIN_STATUS_ERR_SENSOR_INIT_FAIL);
+
+    /* Write configuration registers */
+    for (size_t i = 0; i < sizeof(vl53l4cd_init_regs) / sizeof(manikin_sensor_reg_t); i++)
+    {
+        status = manikin_i2c_write_reg(sensor_ctx->i2c,
+                                     sensor_ctx->i2c_addr,
+                                     vl53l4cd_init_regs[i].reg,
+                                     GET_LOWER_8_BITS_OF_SHORT(vl53l4cd_init_regs[i].val));
+        MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), MANIKIN_STATUS_ERR_SENSOR_INIT_FAIL);
+    }
+    
+    /* Start ranging in continuous mode */
+    status = manikin_i2c_write_reg(sensor_ctx->i2c, 
+                                 sensor_ctx->i2c_addr, 
+                                 VL53L4CD_SYSTEM_START, 
+                                 VL53L4CD_RANGING_START);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), MANIKIN_STATUS_ERR_SENSOR_INIT_FAIL);
+    
+    return MANIKIN_STATUS_OK;
+}
+
+manikin_status_t
+vl53l4cd_read_sensor (manikin_sensor_ctx_t *sensor_ctx, uint8_t *read_buf)
+{
+    manikin_status_t status = vl53l4cd_check_params(sensor_ctx);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Reinitialize if needed */
+    if (sensor_ctx->needs_reinit == 1)
+    {
+        status = vl53l4cd_init_sensor(sensor_ctx);
+        MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    }
+    
+    MANIKIN_ASSERT(HASH_VL53L4CD, (read_buf != NULL), MANIKIN_STATUS_ERR_NULL_PARAM);
+    
+    /* Check for data ready */
+    uint8_t data_ready = 0;
+    status = manikin_i2c_read_reg(sensor_ctx->i2c, 
+                                sensor_ctx->i2c_addr, 
+                                VL53L4CD_SYSTEM_INTERRUPT_CLEAR, 
+                                &data_ready);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Check if data is ready (bit 0) */
+    if (!(data_ready & 0x01))
+    {
+        return MANIKIN_STATUS_ERR_READ_FAIL;
+    }
+    
+    /* Read distance measurement (16-bit value) */
+    uint8_t distance_data[2] = {0};
+    status = manikin_i2c_read_reg16(sensor_ctx->i2c, 
+                                  sensor_ctx->i2c_addr, 
+                                  VL53L4CD_RESULT_FINAL_RANGE_MM, 
+                                  distance_data);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Construct 16-bit distance value */
+    uint16_t distance = (uint16_t)((distance_data[0] << 8) | distance_data[1]);
+    
+    /* To match VL6180X behavior, clip the distance to single byte (0-255mm) */
+    if (distance > 255)
+    {
+        read_buf[0] = 255;
+    }
+    else
+    {
+        read_buf[0] = (uint8_t)distance;
+    }
+    
+    /* Clear the interrupt for next measurement */
+    status = manikin_i2c_write_reg(sensor_ctx->i2c, 
+                                 sensor_ctx->i2c_addr, 
+                                 VL53L4CD_SYSTEM_INTERRUPT_CLEAR, 
+                                 VL53L4CD_CLEAR_INTERRUPT);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    return MANIKIN_STATUS_OK;
+}
+
+manikin_status_t
+vl53l4cd_deinit_sensor (manikin_sensor_ctx_t *sensor_ctx)
+{
+    manikin_status_t status = vl53l4cd_check_params(sensor_ctx);
+    MANIKIN_ASSERT(HASH_VL53L4CD, (status == MANIKIN_STATUS_OK), status);
+    
+    /* Stop ranging */
+    status = manikin_i2c_write_reg(sensor_ctx->i2c, 
+                                 sensor_ctx->i2c_addr, 
+                                 VL53L4CD_SYSTEM_START, 
+                                 VL53L4CD_RANGING_STOP);
+    MANIKIN_ASSERT(HASH_VL53L4CD, 
+                  (status == MANIKIN_STATUS_OK), 
+                  MANIKIN_STATUS_ERR_SENSOR_DEINIT_FAIL);
+    
+    return MANIKIN_STATUS_OK;
+}

--- a/src/vl53l4cd/vl53l4cd.h
+++ b/src/vl53l4cd/vl53l4cd.h
@@ -1,0 +1,71 @@
+/**
+ * @file            vl53l4cd.h
+ * @brief           Driver module for STM VL53L4CD ranging ToF sensor
+ *
+ * @par
+ * Copyright 2025 (C) RobotPatient Simulators
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is part of the Manikin Software Libraries V3 project
+ *
+ * Author:          Johan Korten
+ */
+
+#ifndef VL53L4CD_H
+#define VL53L4CD_H
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "common/manikin_types.h"
+
+    /**
+     * @brief Initialize the sensor, which disables continuous sampling mode.
+     * @param sensor_ctx Ptr to struct containing all settings for sensor, such as i2c instance &
+     * address
+     * @return MANIKIN_STATUS_OK on Successful initialization,
+     *         MANIKIN_STATUS_ERR_SENSOR_INIT_FAIL on unable to set registers (due to lost
+     *          connection, e.g.)
+     *         MANIKIN_STATUS_ERR_NULL_PARAM on invalid i2c handle
+     */
+    manikin_status_t vl53l4cd_init_sensor(manikin_sensor_ctx_t *sensor_ctx);
+
+    /**
+     * @brief Read the sensor, which should read 1-byte of data (distance in mm)
+     * @param sensor_ctx Ptr to struct containing all settings for sensor, such as i2c instance &
+     * address
+     * @param read_buf Ptr to read-buffer which is used for storing the samples
+     * @return MANIKIN_STATUS_OK on success,
+     *         MANIKIN_STATUS_READ_FAIL on failure while reading,
+     *         MANIKIN_STATUS_WRITE_FAIL on failure while writing.
+     */
+    manikin_status_t vl53l4cd_read_sensor(manikin_sensor_ctx_t *sensor_ctx, uint8_t *read_buf);
+
+    /**
+     * @brief Deinitialize the sensor, which disables continuous sampling mode.
+     * @param sensor_ctx Ptr to struct containing all settings for sensor, such as i2c instance &
+     * address
+     * @return MANIKIN_STATUS_OK on Successful initialization,
+     *         MANIKIN_STATUS_ERR_SENSOR_DEINIT_FAIL on unable to set registers (due to lost
+     * connection, e.g.) MANIKIN_STATUS_ERR_NULL_PARAM on invalid i2c handle
+     */
+    manikin_status_t vl53l4cd_deinit_sensor(manikin_sensor_ctx_t *sensor_ctx);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // VL53L4CD_H
+
+// TODO: Remove Examples before pushing

--- a/src/w25qxx128/w25qxx128.c
+++ b/src/w25qxx128/w25qxx128.c
@@ -279,7 +279,6 @@ w25qxx_erase_sector (manikin_spi_memory_ctx_t *mem_ctx, uint32_t sector_number)
     status |= manikin_spi_end_transaction(mem_ctx->spi_cs);
     if (status != MANIKIN_STATUS_OK)
     {
-        manikin_spi_end_transaction(mem_ctx->spi_cs);
         mem_ctx->fault_cnt++;
         return MANIKIN_MEMORY_RESULT_ERROR;
     }

--- a/src/w25qxx128/w25qxx128.c
+++ b/src/w25qxx128/w25qxx128.c
@@ -135,7 +135,6 @@ w25qxx_write (manikin_spi_memory_ctx_t *mem_ctx, uint8_t *data, uint32_t addr, s
     const uint8_t fault_cnt_not_exceeded = mem_ctx->fault_cnt < MANIKIN_FLASH_MAX_RETRIES;
     MANIKIN_ASSERT(W25QXX_HASH, fault_cnt_not_exceeded, MANIKIN_MEMORY_RESULT_NOTRDY);
 
-    addr = addr * W25QXX_PAGE_SIZE;
     // WARNING: Cast in line below
     // Size_t is assumed to be 32-bit, but on 64-bit platform it will be 64-bit.
     // This is not an issue, as the range is limited to 16 MB by assert above. The cast is safe!
@@ -201,7 +200,6 @@ w25qxx_read (manikin_spi_memory_ctx_t *mem_ctx, uint8_t *data, uint32_t addr, si
     manikin_status_t status = w25qxx_check_id(mem_ctx);
     MANIKIN_ASSERT(W25QXX_HASH, status == MANIKIN_STATUS_OK, MANIKIN_MEMORY_RESULT_NOTRDY);
 
-    addr             = addr * W25QXX_PAGE_SIZE;
     size_t remaining = len;
 
     status |= manikin_spi_start_transaction(mem_ctx->spi_cs);
@@ -271,7 +269,11 @@ w25qxx_erase_sector (manikin_spi_memory_ctx_t *mem_ctx, uint32_t sector_number)
     }
 
     status |= w25qxx_set_address(mem_ctx, W25QXX_REG_SECTOR_ERASE, addr);
-
+    if (w25qxx_wait_while_busy(mem_ctx) != MANIKIN_STATUS_OK)
+    {
+        mem_ctx->fault_cnt++;
+        return MANIKIN_MEMORY_RESULT_ERROR;
+    }
     if (status != MANIKIN_STATUS_OK)
     {
         manikin_spi_end_transaction(mem_ctx->spi_cs);

--- a/src/w25qxx128/w25qxx128.c
+++ b/src/w25qxx128/w25qxx128.c
@@ -268,19 +268,21 @@ w25qxx_erase_sector (manikin_spi_memory_ctx_t *mem_ctx, uint32_t sector_number)
         return MANIKIN_MEMORY_RESULT_ERROR;
     }
 
+    status |= manikin_spi_start_transaction(mem_ctx->spi_cs);
     status |= w25qxx_set_address(mem_ctx, W25QXX_REG_SECTOR_ERASE, addr);
-    if (w25qxx_wait_while_busy(mem_ctx) != MANIKIN_STATUS_OK)
+    if ((status != MANIKIN_STATUS_OK) || (w25qxx_wait_while_busy(mem_ctx) != MANIKIN_STATUS_OK))
     {
+        manikin_spi_end_transaction(mem_ctx->spi_cs);
         mem_ctx->fault_cnt++;
         return MANIKIN_MEMORY_RESULT_ERROR;
     }
+    status |= manikin_spi_end_transaction(mem_ctx->spi_cs);
     if (status != MANIKIN_STATUS_OK)
     {
         manikin_spi_end_transaction(mem_ctx->spi_cs);
         mem_ctx->fault_cnt++;
         return MANIKIN_MEMORY_RESULT_ERROR;
     }
-
     return MANIKIN_MEMORY_RESULT_OK;
 }
 

--- a/src/w25qxx128/w25qxx128.c
+++ b/src/w25qxx128/w25qxx128.c
@@ -269,6 +269,12 @@ w25qxx_erase_sector (manikin_spi_memory_ctx_t *mem_ctx, uint32_t sector_number)
     }
 
     status |= manikin_spi_start_transaction(mem_ctx->spi_cs);
+    if (status != MANIKIN_STATUS_OK)
+    {
+        manikin_spi_end_transaction(mem_ctx->spi_cs);
+        mem_ctx->fault_cnt++;
+        return MANIKIN_MEMORY_RESULT_ERROR;
+    }
     status |= w25qxx_set_address(mem_ctx, W25QXX_REG_SECTOR_ERASE, addr);
     if ((status != MANIKIN_STATUS_OK) || (w25qxx_wait_while_busy(mem_ctx) != MANIKIN_STATUS_OK))
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,10 @@ add_executable(test_vl6180 ${CMAKE_CURRENT_LIST_DIR}/vl6180x/test_vl6180x.cpp)
 target_link_libraries(test_vl6180 ${PROJECT_NAME} Catch2 fff hal_mock)
 catch_discover_tests(test_vl6180)
 
+add_executable(test_vl53l4cd ${CMAKE_CURRENT_LIST_DIR}/vl53l4cd/test_vl53l4cd.cpp)
+target_link_libraries(test_vl53l4cd ${PROJECT_NAME} Catch2 fff hal_mock)
+catch_discover_tests(test_vl53l4cd)
+
 add_executable(test_sdp810 ${CMAKE_CURRENT_LIST_DIR}/sdp810/test_sdp810.cpp)
 target_link_libraries(test_sdp810 ${PROJECT_NAME} Catch2 fff hal_mock)
 catch_discover_tests(test_sdp810)

--- a/tests/vl53l4cd/test_vl53l4cd.cpp
+++ b/tests/vl53l4cd/test_vl53l4cd.cpp
@@ -1,26 +1,26 @@
 /**
-* @file             test_vl53l4cd.cpp
-* @brief           Test for STM VL53L4CD ranging ToF sensor software module
-*
-* @par
-* Copyright 2025 (C) RobotPatient Simulators
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* This file is part of the Manikin Software Libraries V3 project
-*
-* Author:          Jakob Korten
-*/
+ * @file             test_vl53l4cd.cpp
+ * @brief           Test for STM VL53L4CD ranging ToF sensor software module
+ *
+ * @par
+ * Copyright 2025 (C) RobotPatient Simulators
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is part of the Manikin Software Libraries V3 project
+ *
+ * Author:          Johan Korten
+ */
 
 #include "catch2/catch_all.hpp"
 #include <catch2/catch_session.hpp>
@@ -33,220 +33,227 @@ static uint8_t       dummy_read_buf[4];
 static uint8_t       handle = 1;
 manikin_sensor_ctx_t dummy_ctx;
 
-#define VL53L4CD_I2C_ADDR              0x52u
+#define VL53L4CD_I2C_ADDR                  0x52u
 #define VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET 0x0016u
-#define VL53L4CD_IDENTIFICATION_MODEL_ID 0x010Fu
-#define VL53L4CD_RESULT_FINAL_RANGE_MM  0x0096u
-#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR 0x0086u
+#define VL53L4CD_IDENTIFICATION_MODEL_ID   0x010Fu
+#define VL53L4CD_RESULT_FINAL_RANGE_MM     0x0096u
+#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR    0x0086u
 
 // For simulating sensor values
 uint16_t cur_reg;
-uint8_t data_ready = 1;
-uint8_t model_id_high = 0xEA;
-uint8_t model_id_low = 0xCC;
+uint8_t  data_ready    = 1;
+uint8_t  model_id_high = 0xEA;
+uint8_t  model_id_low  = 0xCC;
 
 // Custom read function that simulates a large distance value (over 255mm)
 size_t
-custom_read_large_distance(manikin_i2c_inst_t handle, uint8_t i2c_addr, uint8_t *bytes, size_t len)
+custom_read_large_distance (manikin_i2c_inst_t handle, uint8_t i2c_addr, uint8_t *bytes, size_t len)
 {
-   if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
-   {
-       cur_reg = 0;
-       bytes[0] = 1u; // Signal that sensor is ready
-   }
-   else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
-   {
-       bytes[0] = model_id_high;
-       bytes[1] = model_id_low;
-       cur_reg = 0;
-   }
-   else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
-   {
-       bytes[0] = data_ready; // Data ready flag
-       cur_reg = 0;
-   }
-   else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
-   {
-       // Return simulated distance of 500mm (larger than 255)
-       bytes[0] = 0x01; // high byte
-       bytes[1] = 0xF4; // low byte (500 decimal = 0x01F4)
-       cur_reg = 0;
-   }
-   else
-   {
-       cur_reg = 0u;
-       if (len >= 1) bytes[0] = 0x01u;
-       if (len >= 2) bytes[1] = 0x01u;
-   }
-   return len;
+    if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
+    {
+        cur_reg  = 0;
+        bytes[0] = 1u; // Signal that sensor is ready
+    }
+    else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
+    {
+        bytes[0] = model_id_high;
+        bytes[1] = model_id_low;
+        cur_reg  = 0;
+    }
+    else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
+    {
+        bytes[0] = data_ready; // Data ready flag
+        cur_reg  = 0;
+    }
+    else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
+    {
+        // Return simulated distance of 500mm (larger than 255)
+        bytes[0] = 0x01; // high byte
+        bytes[1] = 0xF4; // low byte (500 decimal = 0x01F4)
+        cur_reg  = 0;
+    }
+    else
+    {
+        cur_reg = 0u;
+        if (len >= 1)
+        {
+            bytes[0] = 0x01u;
+        }
+        if (len >= 2)
+        {
+            bytes[1] = 0x01u;
+        }
+    }
+    return len;
 }
 
 size_t
 custom_write_func (manikin_i2c_inst_t handle, uint8_t i2c_addr, const uint8_t *bytes, size_t len)
 {
-   if (len >= sizeof(uint16_t))
-   {
-       cur_reg = CONSTRUCT_SHORT_FROM_BYTES(bytes[0], bytes[1]);
-   }
-   return len;
+    if (len >= sizeof(uint16_t))
+    {
+        cur_reg = CONSTRUCT_SHORT_FROM_BYTES(bytes[0], bytes[1]);
+    }
+    return len;
 }
 
 size_t
 custom_read_func (manikin_i2c_inst_t handle, uint8_t i2c_addr, uint8_t *bytes, size_t len)
 {
-   if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
-   {
-       cur_reg = 0;
-       // Signal that sensor is ready
-       bytes[0] = 1u;
-   }
-   else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
-   {
-       // Return model ID
-       bytes[0] = model_id_high;
-       bytes[1] = model_id_low;
-       cur_reg = 0;
-   }
-   else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
-   {
-       // Return data ready flag
-       bytes[0] = data_ready;
-       cur_reg = 0;
-   }
-   else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
-   {
-       // Return simulated distance of 150mm
-       bytes[0] = 0x00;
-       bytes[1] = 0x96; // 150 decimal
-       cur_reg = 0;
-   }
-   else
-   {
-       cur_reg = 0u;
-       if (len >= 1)
-       {
-           bytes[0] = 0x01u;
-       }
-       if (len >= 2)
-       {
-           bytes[1] = 0x01u;
-       }
-   }
-   return len;
+    if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
+    {
+        cur_reg = 0;
+        // Signal that sensor is ready
+        bytes[0] = 1u;
+    }
+    else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
+    {
+        // Return model ID
+        bytes[0] = model_id_high;
+        bytes[1] = model_id_low;
+        cur_reg  = 0;
+    }
+    else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
+    {
+        // Return data ready flag
+        bytes[0] = data_ready;
+        cur_reg  = 0;
+    }
+    else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
+    {
+        // Return simulated distance of 150mm
+        bytes[0] = 0x00;
+        bytes[1] = 0x96; // 150 decimal
+        cur_reg  = 0;
+    }
+    else
+    {
+        cur_reg = 0u;
+        if (len >= 1)
+        {
+            bytes[0] = 0x01u;
+        }
+        if (len >= 2)
+        {
+            bytes[1] = 0x01u;
+        }
+    }
+    return len;
 }
 
 void
 reset_mocks ()
 {
-   RESET_FAKE(i2c_hal_init);
-   RESET_FAKE(i2c_hal_error_flag_check);
-   RESET_FAKE(i2c_hal_read_bytes);
-   RESET_FAKE(i2c_hal_write_bytes);
-   RESET_FAKE(i2c_hal_deinit);
-   data_ready = 1;
-   cur_reg = 0;
+    RESET_FAKE(i2c_hal_init);
+    RESET_FAKE(i2c_hal_error_flag_check);
+    RESET_FAKE(i2c_hal_read_bytes);
+    RESET_FAKE(i2c_hal_write_bytes);
+    RESET_FAKE(i2c_hal_deinit);
+    data_ready = 1;
+    cur_reg    = 0;
 }
 
 TEST_CASE("vl53l4cd_init_sensor handles null parameter", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   REQUIRE(vl53l4cd_init_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+    reset_mocks();
+    REQUIRE(vl53l4cd_init_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
 }
 
 TEST_CASE("vl53l4cd_init_sensor succeeds with valid context", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   REQUIRE(vl53l4cd_init_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    REQUIRE(vl53l4cd_init_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
 }
 
 TEST_CASE("vl53l4cd_read_sensor fails with null context", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   REQUIRE(vl53l4cd_read_sensor(NULL, dummy_read_buf) == MANIKIN_STATUS_ERR_NULL_PARAM);
+    reset_mocks();
+    REQUIRE(vl53l4cd_read_sensor(NULL, dummy_read_buf) == MANIKIN_STATUS_ERR_NULL_PARAM);
 }
 
 TEST_CASE("vl53l4cd_read_sensor fails with null read buffer", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
 }
 
 TEST_CASE("vl53l4cd_read_sensor reads successfully", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   uint8_t read_buf[1]                  = { 0 };
-   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
-   REQUIRE(read_buf[0] == 150);
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    uint8_t read_buf[1]                  = { 0 };
+    REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+    REQUIRE(read_buf[0] == 150);
 }
 
 TEST_CASE("vl53l4cd_read_sensor clips distances over 255mm to 255", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_large_distance;
-   
-   uint8_t read_buf[1] = { 0 };
-   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
-   REQUIRE(read_buf[0] == 255); // Should be clipped to 255
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_large_distance;
+
+    uint8_t read_buf[1] = { 0 };
+    REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+    REQUIRE(read_buf[0] == 255); // Should be clipped to 255
 }
 
 TEST_CASE("vl53l4cd_read_sensor fails when data not ready", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   data_ready                           = 0; // Data not ready
-   uint8_t read_buf[1]                  = { 0 };
-   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_ERR_READ_FAIL);
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    data_ready                           = 0; // Data not ready
+    uint8_t read_buf[1]                  = { 0 };
+    REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_ERR_READ_FAIL);
 }
 
 TEST_CASE("vl53l4cd_deinit_sensor handles null context", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   REQUIRE(vl53l4cd_deinit_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+    reset_mocks();
+    REQUIRE(vl53l4cd_deinit_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
 }
 
 TEST_CASE("vl53l4cd_deinit_sensor succeeds with valid context", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   REQUIRE(vl53l4cd_deinit_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    REQUIRE(vl53l4cd_deinit_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
 }
 
 TEST_CASE("vl53l4cd_read_sensor reinitializes when needed", "[vl53l4cd][REQ-F1]")
 {
-   reset_mocks();
-   dummy_ctx.i2c                        = &handle;
-   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
-   dummy_ctx.needs_reinit               = 1; // Needs reinitialization
-   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
-   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
-   uint8_t read_buf[1]                  = { 0 };
-   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
-   REQUIRE(dummy_ctx.needs_reinit == 0); // Flag should be cleared
+    reset_mocks();
+    dummy_ctx.i2c                        = &handle;
+    dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+    dummy_ctx.needs_reinit               = 1; // Needs reinitialization
+    i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+    i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+    uint8_t read_buf[1]                  = { 0 };
+    REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+    REQUIRE(dummy_ctx.needs_reinit == 0); // Flag should be cleared
 }
 
-int main (int argc, char *argv[])
+int
+main (int argc, char *argv[])
 {
-   int result = Catch::Session().run(argc, argv);
-   return result;
+    int result = Catch::Session().run(argc, argv);
+    return result;
 }

--- a/tests/vl53l4cd/test_vl53l4cd.cpp
+++ b/tests/vl53l4cd/test_vl53l4cd.cpp
@@ -1,0 +1,252 @@
+/**
+* @file             test_vl53l4cd.cpp
+* @brief           Test for STM VL53L4CD ranging ToF sensor software module
+*
+* @par
+* Copyright 2025 (C) RobotPatient Simulators
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* This file is part of the Manikin Software Libraries V3 project
+*
+* Author:          Jakob Korten
+*/
+
+#include "catch2/catch_all.hpp"
+#include <catch2/catch_session.hpp>
+#include "vl53l4cd/vl53l4cd.h"
+#include "fake_i2c_functions.h"
+#include "common/manikin_bit_manipulation.h"
+
+// Common mocks and types
+static uint8_t       dummy_read_buf[4];
+static uint8_t       handle = 1;
+manikin_sensor_ctx_t dummy_ctx;
+
+#define VL53L4CD_I2C_ADDR              0x52u
+#define VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET 0x0016u
+#define VL53L4CD_IDENTIFICATION_MODEL_ID 0x010Fu
+#define VL53L4CD_RESULT_FINAL_RANGE_MM  0x0096u
+#define VL53L4CD_SYSTEM_INTERRUPT_CLEAR 0x0086u
+
+// For simulating sensor values
+uint16_t cur_reg;
+uint8_t data_ready = 1;
+uint8_t model_id_high = 0xEA;
+uint8_t model_id_low = 0xCC;
+
+// Custom read function that simulates a large distance value (over 255mm)
+size_t
+custom_read_large_distance(manikin_i2c_inst_t handle, uint8_t i2c_addr, uint8_t *bytes, size_t len)
+{
+   if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
+   {
+       cur_reg = 0;
+       bytes[0] = 1u; // Signal that sensor is ready
+   }
+   else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
+   {
+       bytes[0] = model_id_high;
+       bytes[1] = model_id_low;
+       cur_reg = 0;
+   }
+   else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
+   {
+       bytes[0] = data_ready; // Data ready flag
+       cur_reg = 0;
+   }
+   else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
+   {
+       // Return simulated distance of 500mm (larger than 255)
+       bytes[0] = 0x01; // high byte
+       bytes[1] = 0xF4; // low byte (500 decimal = 0x01F4)
+       cur_reg = 0;
+   }
+   else
+   {
+       cur_reg = 0u;
+       if (len >= 1) bytes[0] = 0x01u;
+       if (len >= 2) bytes[1] = 0x01u;
+   }
+   return len;
+}
+
+size_t
+custom_write_func (manikin_i2c_inst_t handle, uint8_t i2c_addr, const uint8_t *bytes, size_t len)
+{
+   if (len >= sizeof(uint16_t))
+   {
+       cur_reg = CONSTRUCT_SHORT_FROM_BYTES(bytes[0], bytes[1]);
+   }
+   return len;
+}
+
+size_t
+custom_read_func (manikin_i2c_inst_t handle, uint8_t i2c_addr, uint8_t *bytes, size_t len)
+{
+   if (len >= sizeof(uint8_t) && cur_reg == VL53L4CD_SYSTEM_FRESH_OUT_OF_RESET)
+   {
+       cur_reg = 0;
+       // Signal that sensor is ready
+       bytes[0] = 1u;
+   }
+   else if (cur_reg == VL53L4CD_IDENTIFICATION_MODEL_ID && len >= 2)
+   {
+       // Return model ID
+       bytes[0] = model_id_high;
+       bytes[1] = model_id_low;
+       cur_reg = 0;
+   }
+   else if (cur_reg == VL53L4CD_SYSTEM_INTERRUPT_CLEAR && len >= 1)
+   {
+       // Return data ready flag
+       bytes[0] = data_ready;
+       cur_reg = 0;
+   }
+   else if (cur_reg == VL53L4CD_RESULT_FINAL_RANGE_MM && len >= 2)
+   {
+       // Return simulated distance of 150mm
+       bytes[0] = 0x00;
+       bytes[1] = 0x96; // 150 decimal
+       cur_reg = 0;
+   }
+   else
+   {
+       cur_reg = 0u;
+       if (len >= 1)
+       {
+           bytes[0] = 0x01u;
+       }
+       if (len >= 2)
+       {
+           bytes[1] = 0x01u;
+       }
+   }
+   return len;
+}
+
+void
+reset_mocks ()
+{
+   RESET_FAKE(i2c_hal_init);
+   RESET_FAKE(i2c_hal_error_flag_check);
+   RESET_FAKE(i2c_hal_read_bytes);
+   RESET_FAKE(i2c_hal_write_bytes);
+   RESET_FAKE(i2c_hal_deinit);
+   data_ready = 1;
+   cur_reg = 0;
+}
+
+TEST_CASE("vl53l4cd_init_sensor handles null parameter", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   REQUIRE(vl53l4cd_init_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+}
+
+TEST_CASE("vl53l4cd_init_sensor succeeds with valid context", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   REQUIRE(vl53l4cd_init_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
+}
+
+TEST_CASE("vl53l4cd_read_sensor fails with null context", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   REQUIRE(vl53l4cd_read_sensor(NULL, dummy_read_buf) == MANIKIN_STATUS_ERR_NULL_PARAM);
+}
+
+TEST_CASE("vl53l4cd_read_sensor fails with null read buffer", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+}
+
+TEST_CASE("vl53l4cd_read_sensor reads successfully", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   uint8_t read_buf[1]                  = { 0 };
+   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+   REQUIRE(read_buf[0] == 150);
+}
+
+TEST_CASE("vl53l4cd_read_sensor clips distances over 255mm to 255", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_large_distance;
+   
+   uint8_t read_buf[1] = { 0 };
+   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+   REQUIRE(read_buf[0] == 255); // Should be clipped to 255
+}
+
+TEST_CASE("vl53l4cd_read_sensor fails when data not ready", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   data_ready                           = 0; // Data not ready
+   uint8_t read_buf[1]                  = { 0 };
+   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_ERR_READ_FAIL);
+}
+
+TEST_CASE("vl53l4cd_deinit_sensor handles null context", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   REQUIRE(vl53l4cd_deinit_sensor(NULL) == MANIKIN_STATUS_ERR_NULL_PARAM);
+}
+
+TEST_CASE("vl53l4cd_deinit_sensor succeeds with valid context", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   REQUIRE(vl53l4cd_deinit_sensor(&dummy_ctx) == MANIKIN_STATUS_OK);
+}
+
+TEST_CASE("vl53l4cd_read_sensor reinitializes when needed", "[vl53l4cd][REQ-F1]")
+{
+   reset_mocks();
+   dummy_ctx.i2c                        = &handle;
+   dummy_ctx.i2c_addr                   = VL53L4CD_I2C_ADDR;
+   dummy_ctx.needs_reinit               = 1; // Needs reinitialization
+   i2c_hal_write_bytes_fake.custom_fake = custom_write_func;
+   i2c_hal_read_bytes_fake.custom_fake  = custom_read_func;
+   uint8_t read_buf[1]                  = { 0 };
+   REQUIRE(vl53l4cd_read_sensor(&dummy_ctx, read_buf) == MANIKIN_STATUS_OK);
+   REQUIRE(dummy_ctx.needs_reinit == 0); // Flag should be cleared
+}
+
+int main (int argc, char *argv[])
+{
+   int result = Catch::Session().run(argc, argv);
+   return result;
+}


### PR DESCRIPTION
This pull request introduces a new driver implementation for the STM VL53L4CD ranging ToF sensor, along with its integration into the build system, unit tests, and minor fixes in related files. Below is a summary of the most important changes:

### VL53L4CD Sensor Driver Implementation:
* Added a new driver for the VL53L4CD sensor, including initialization, reading, and deinitialization functions (`src/vl53l4cd/vl53l4cd.c`, `src/vl53l4cd/vl53l4cd.h`). [[1]](diffhunk://#diff-d04abd5102bca422110245985053a85031908a51819f7dc424e85c75c6831350R1-R181) [[2]](diffhunk://#diff-c7922752b4894ff784b11baf3ad7e08b9179da2086fbaab175478f31c12c5130R1-R71)
* Created a private header file defining the sensor's register map (`src/vl53l4cd/private/vl53l4cd_regs.h`).

### Build System Updates:
* Integrated the VL53L4CD driver into the build system by adding its source file to `CMakeLists.txt`.
* Added a new test executable for the VL53L4CD sensor in the test CMake configuration (`tests/CMakeLists.txt`).

### Unit Tests:
* Developed unit tests for the VL53L4CD driver to validate its behavior, including edge cases such as null parameters and clipping distance values (`tests/vl53l4cd/test_vl53l4cd.cpp`).

### Bug Fixes and Enhancements in Related Code:
* Removed redundant address calculation in `w25qxx_read` and `w25qxx_write` functions (`src/w25qxx128/w25qxx128.c`). [[1]](diffhunk://#diff-d00cff4584eafd70b9b0550f2e677980b459238edc664b94fb890cb298549820L138) [[2]](diffhunk://#diff-d00cff4584eafd70b9b0550f2e677980b459238edc664b94fb890cb298549820L204)
* Added error handling for the sector erase operation in `w25qxx_erase_sector` to increment the fault counter on failure (`src/w25qxx128/w25qxx128.c`).
* Added wait loop for  sector erase operation in `w25qxx_erase_sector` to make sure it waits for full sector erasure before proceeding. Blocking call (as that is what litlefs requires) (`src/w25qxx128/w25qxx128.c`).